### PR TITLE
Add permission controls for employees

### DIFF
--- a/server.py
+++ b/server.py
@@ -136,6 +136,13 @@ def add_assignment_record():
     _save_assignments()
     return jsonify({'status': 'ok'}), 201
 
+@app.route('/api/assignments/<int:idx>', methods=['DELETE'])
+def delete_assignment_record(idx):
+    if 0 <= idx < len(assignments):
+        assignments.pop(idx)
+        _save_assignments()
+    return jsonify({'status': 'ok'})
+
 # --- REST для зон ---
 @app.route('/api/environments/<eid>/zones', methods=['GET'])
 def get_zones(eid):


### PR DESCRIPTION
## Summary
- add room selection widget on employee screen
- refresh available rooms and assignments when employee screen opens
- store selected room and require it for identification start
- add button to save access permission on manager screen
- check saved assignments before granting access
- replace manager 'Назначить' button with 'Сохранить допуск'
- add list of issued permissions with delete option

## Testing
- `python3 -m py_compile 12.py server.py`
